### PR TITLE
Resolve reflection in optimizations ns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Fixed
 
+- Resolved reflection in `lambdaisland.clj-diff.optimizations`
+
 ## Changed
 
 # 1.4.78 (2022-11-25 / 2c3cae0)

--- a/bin/kaocha
+++ b/bin/kaocha
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-clojure -A:dev:test -m kaocha.runner "$@"
+clojure -M:dev:test -m kaocha.runner "$@"

--- a/src/clj/lambdaisland/clj_diff/optimizations.clj
+++ b/src/clj/lambdaisland/clj_diff/optimizations.clj
@@ -3,6 +3,8 @@
   See http://neil.fraser.name/writing/diff/."
   (:import lambdaisland.clj_diff.FastStringOps))
 
+(set! *warn-on-reflection* true)
+
 (defn common-prefix [^String a ^String b]
   (let [i (FastStringOps/commonPrefix a b)]
     [i (.substring a i) (.substring b i)]))
@@ -17,7 +19,7 @@
   "Return a diff if the shorter sequence exists in the longer one. No need to
   use the expensive diff algorithm for this."
   [^String a ^String b ^Integer ca ^Integer cb]
-  (let [[short long] (if (> ca cb) [b a] [a b])
+  (let [[^String short ^String long] (if (> ca cb) [b a] [a b])
         i (int (.indexOf long short))]
     (if (= i -1)
       nil


### PR DESCRIPTION
This line pops up sometimes when running kaocha as a reflection warning.

```
Reflection warning, lambdaisland/clj_diff/optimizations.clj:21:16 - call to method indexOf on java.lang.Object can't be resolved (no such method).
```